### PR TITLE
fix(package): update @ethereum-alarm-clock/timenode-core to version 4…

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/ethereum-alarm-clock/eac.js-cli#readme",
   "dependencies": {
-    "@ethereum-alarm-clock/timenode-core": "4.2.11",
+    "@ethereum-alarm-clock/timenode-core": "4.3.1",
     "bignumber.js": "5.0.0",
     "bluebird": "3.5.1",
     "clear": "0.1.0",


### PR DESCRIPTION
….3.1

Closes #99